### PR TITLE
add ucb and ei

### DIFF
--- a/acquisition.py
+++ b/acquisition.py
@@ -98,7 +98,7 @@ class AcquisitionFunctionProxy(AcquisitionFunctionBase):
         inputs = pad_sequence(inputs_af, batch_first=True, padding_value=0.0)
 
         self.load_best_proxy()
-        self.proxy.model.eval()
+        self.proxy.model.train()
         with torch.no_grad():
             if self.config.proxy.model.lower() == "mlp":
                 outputs = self.proxy.model(inputs)
@@ -125,7 +125,7 @@ class AcquisitionFunctionUCB(AcquisitionFunctionBase):
         inputs = pad_sequence(inputs_af, batch_first=True, padding_value=0.0)
 
         self.load_best_proxy()
-        self.proxy.model.eval()
+        self.proxy.model.train()
         with torch.no_grad():
             if self.config.proxy.model.lower() == "mlp":
                 outputs = (
@@ -200,7 +200,7 @@ class AcquisitionFunctionEI(AcquisitionFunctionBase):
         self.getMinF(inputs, input_afs_lens, None)
 
         self.load_best_proxy()
-        self.proxy.model.eval()
+        self.proxy.model.train()
         with torch.no_grad():
             if self.config.proxy.model.lower() == "mlp":
                 outputs = (

--- a/acquisition.py
+++ b/acquisition.py
@@ -22,7 +22,7 @@ class AcquisitionFunction:
         # so far, only proxy acquisition function has been implemented, only add new acquisition class inheriting from AcquisitionFunctionBase to innovate
         if self.config.acquisition.main.lower() == "proxy":
             self.acq = AcquisitionFunctionProxy(self.config, self.proxy)
-        elif self.config.acquisition.main == "oracle":
+        elif self.config.acquisition.main.lower() == "oracle":
             self.acq = AcquisitionFunctionOracle(self.config, self.proxy)
         elif self.config.acquisition.main.lower() == "ucb":
             self.acq = AcquisitionFunctionUCB(self.config, self.proxy)

--- a/acquisition.py
+++ b/acquisition.py
@@ -3,13 +3,17 @@ import torch
 import torch.nn.functional as F
 from abc import abstractmethod
 from torch.nn.utils.rnn import pad_sequence
+import numpy as np
 
+def l2r(x):
+    r_max = 0
+    r_norm = 1
+    score = torch.clip(x, min=-np.inf, max=r_max).sigmoid() / r_norm
+    return score.cpu().detach()
 
 """
 ACQUISITION WRAPPER
 """
-
-
 class AcquisitionFunction:
     def __init__(self, config, proxy):
         self.config = config
@@ -19,8 +23,12 @@ class AcquisitionFunction:
 
     def init_acquisition(self):
         # so far, only proxy acquisition function has been implemented, only add new acquisition class inheriting from AcquisitionFunctionBase to innovate
-        if self.config.acquisition.main == "proxy":
+        if self.config.acquisition.main.lower() == "proxy":
             self.acq = AcquisitionFunctionProxy(self.config, self.proxy)
+        elif self.config.acquisition.main.lower() == "ucb":
+            self.acq = AcquisitionFunctionUCB(self.config, self.proxy)
+        elif self.config.acquisition.main.lower() == "ei":
+            self.acq = AcquisitionFunctionEI(self.config, self.proxy) 
         else:
             raise NotImplementedError
 
@@ -96,3 +104,82 @@ class AcquisitionFunctionProxy(AcquisitionFunctionBase):
                 outputs = self.proxy.model(inputs, None)
 
         return outputs
+
+
+class AcquisitionFunctionUCB(AcquisitionFunctionBase):
+    def __init__(self, config, proxy):
+        super().__init__(config, proxy)
+
+    def load_best_proxy(self):
+        super().load_best_proxy()
+
+    def get_reward_batch(self, inputs_af_base):  # inputs_af = list of ...
+        super().get_reward_batch(inputs_af_base)
+
+        inputs_af = list(map(torch.tensor, inputs_af_base))
+        input_afs_lens = list(map(len, inputs_af_base))
+        inputs = pad_sequence(inputs_af, batch_first=True, padding_value=0.0)
+
+        self.load_best_proxy()
+        self.proxy.model.eval()
+        with torch.no_grad():
+            if self.config.proxy.model.lower() == "mlp":
+                outputs = torch.hstack([self.proxy.model(inputs) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+            elif self.config.proxy.model.lower() == "lstm":
+                outputs = torch.hstack([self.proxy.model(inputs, input_afs_lens) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+            elif self.config.proxy.model.lower() == "transformer":
+                outputs = torch.hstack([self.proxy.model(inputs, None) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+        mean = np.mean(outputs, axis=1)
+        std = np.std(outputs, axis=1)
+        score = mean + self.config.acquisition.ucb.kappa * std
+        score = l2r(torch.Tensor(score))
+        score = score.unsqueeze(1)
+        return score
+
+class AcquisitionFunctionEI(AcquisitionFunctionBase):
+    def __init__(self, config, proxy):
+        super().__init__(config, proxy)
+
+    def load_best_proxy(self):
+        super().load_best_proxy()
+
+    def getMinF(self, inputs, input_len, mask):
+        # inputs = torch.Tensor(inputs).to(self.config.device)
+
+        if self.config.proxy.model.lower() == "mlp":
+            outputs = self.proxy.model(inputs)
+        elif self.config.proxy.model.lower() == "lstm":
+            outputs = self.proxy.model(inputs, input_len)
+        elif self.config.proxy.model.lower() == "transformer":
+            outputs = self.proxy.model(inputs, None)
+        
+        outputs = l2r(outputs)
+        self.best_f = np.percentile(outputs, self.config.acquisition.ei.max_percentile)
+
+    def get_reward_batch(self, inputs_af_base):  # inputs_af = list of ...
+        super().get_reward_batch(inputs_af_base)
+        inputs_af = list(map(torch.tensor, inputs_af_base))
+        input_afs_lens = list(map(len, inputs_af_base))
+        inputs = pad_sequence(inputs_af, batch_first=True, padding_value=0.0)
+
+        self.getMinF(inputs, input_afs_lens, None)
+
+        self.load_best_proxy()
+        self.proxy.model.eval()
+        with torch.no_grad():
+            if self.config.proxy.model.lower() == "mlp":
+                outputs = torch.hstack([self.proxy.model(inputs) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+            elif self.config.proxy.model.lower() == "lstm":
+                outputs = torch.hstack([self.proxy.model(inputs, input_afs_lens) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+            elif self.config.proxy.model.lower() == "transformer":
+                outputs = torch.hstack([self.proxy.model(inputs, None) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+        outputs = l2r(torch.Tensor(outputs)) #convert to tensor to use torch operations
+        mean, std = torch.mean(outputs,dim=1), torch.std(outputs,dim=1)
+        u = (mean - self.best_f) / (std + 1e-4)
+        normal = torch.distributions.Normal(torch.zeros_like(u), torch.ones_like(u))
+        ucdf = normal.cdf(u)
+        updf = torch.exp(normal.log_prob(u))
+        ei = std * (updf + u * ucdf)
+        ei = ei.cpu().detach()
+        return ei
+        

--- a/config_test.yaml
+++ b/config_test.yaml
@@ -1,4 +1,4 @@
-device : "cpu"
+device : "cuda"
 debug : True
 
 al:
@@ -20,7 +20,7 @@ env:
   max_word_len : 1
 
 oracle:
-  main : "mlp"
+  main : "nupack"
   init_dataset:
     seed : 0
     init_len : 100
@@ -36,6 +36,7 @@ proxy:
   data:
     shuffle: True
     seed : 10
+  dropout_samples: 20
 
 gflownet:
   policy_model : "mlp"
@@ -63,7 +64,11 @@ gflownet:
     ttsr : 3
 
 acquisition:
-  main: "proxy"
+  main: "ei"
+  ucb:
+    kappa: 0.1
+  ei:
+    max_percentile: 80
   
 
   

--- a/proxy.py
+++ b/proxy.py
@@ -201,7 +201,6 @@ class ProxyBase:
         targets = data[1]
         inputs = inputs.to(self.device)
         targets = targets.to(self.device)
-        # output = self.model(inputs.float())
         output = self.model(inputs)
         loss = F.mse_loss(output[:, 0], targets.float())
         return loss
@@ -550,6 +549,7 @@ class MLP(nn.Module):
     def forward(self, x):
         if self.transformerCall == False:
             x = self.preprocess(x)
+        x = x.to(self.device)
         return self.model(x)
 
     def preprocess(self, inputs):
@@ -596,6 +596,7 @@ class LSTM(nn.Module):
 
     def forward(self, inputs, inputLens):
         x = self.preprocess(inputs)
+        x = x.to(self.device)
         xPack = pack_padded_sequence(
             x, inputLens, batch_first=True, enforce_sorted=False
         )
@@ -677,6 +678,7 @@ class Transformer(nn.Module):
 
     def forward(self, x, mask):
         x = self.preprocess(x)
+        x = x.to(self.device)
         x = self.embedding(x)
         x = self.pos(x)
         x = self.encoder(x, src_key_padding_mask=mask)


### PR DESCRIPTION
There was some stuff in the previous code that did not make complete sense to me so I didn't implement them here. My understanding might be totally wrong so I am enlisting them below so that you guys can correct me:
1. The need to scale up the mean and variance in ucb [[link to code line](https://github.com/alexhernandezgarcia/ActiveLearningPipeline/blob/2ae63854ecb6a46a750b1d76755c61c57dc3f2e1/previous_code/models.py#L263)]
2. I wasn't too sure why we should return the uncertainty along with the score [[link](https://github.com/alexhernandezgarcia/ActiveLearningPipeline/blob/2ae63854ecb6a46a750b1d76755c61c57dc3f2e1/previous_code/models.py#L267)] -- like what do we aim to learn from the uncertainty?
3. Taking the negative value of `u` [[link](https://github.com/alexhernandezgarcia/ActiveLearningPipeline/blob/2ae63854ecb6a46a750b1d76755c61c57dc3f2e1/previous_code/models.py#L278)]
4. Also I am not too sure why `l2r()` is applied on `outputs` instead of on `ei` in the previous code of expected improvement [[link](https://github.com/alexhernandezgarcia/ActiveLearningPipeline/blob/main/models.py#L275)]. For now, I've applied it on `ei` as done in the previous cod.

For now, I added the default values in the argument parser [here](https://github.com/alexhernandezgarcia/ActiveLearningPipeline/blob/main/main.py#L232) to our config_test.yaml file. We could modify them depending on our experiments.

For future, it might be a good idea to have a `forward_with_uncertainty()` which could execute the dropout logic instead of writing the `hstack` code repeatedly. (Might be also useful for other acquisition functions like MES.

There will be a merge conflict once the previous PR is merged (change different interfaces of the model into a single kind of interface) -- I will resolve that.

Minor change in proxy.py to bring the inputs on the device as was running into an error when I shifted to `cuda`
